### PR TITLE
Do not try to rpmlint when releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       - name: build rpm
         run: |
           make clean rpm
-          rpmlint --file .rpmlint.ini build/RPMS/noarch/*.rpm
       - name: Upload RPMs
         uses: actions/upload-artifact@v3
         with:
@@ -49,7 +48,6 @@ jobs:
       - name: build rpm
         run: |
           make clean rpm
-          rpmlint --file .rpmlint.ini build/RPMS/noarch/*.rpm
       - name: Upload RPMs
         uses: actions/upload-artifact@v3
         with:
@@ -73,7 +71,6 @@ jobs:
       - name: build rpm
         run: |
           make clean rpm
-          rpmlint --file .rpmlint.ini build/RPMS/noarch/*.rpm
       - name: Upload RPMs
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Do not try to rpmlint when releasing: of course there was an error in the in the release actions, that was trying to run rpmlint while it's not installed.
There is no point of running rpmlint at that time, as it's already done in the PR.

Finally tested in my fork: https://github.com/gwarf/glite-info-plugin-delayed-delete-status/actions/runs/3713678044 and https://github.com/gwarf/glite-info-plugin-delayed-delete-status/releases/tag/v2.0.0.

Sorry, I shamelessly deleted the broken tag/release...